### PR TITLE
How about this?

### DIFF
--- a/R/cheers_checker.R
+++ b/R/cheers_checker.R
@@ -106,27 +106,48 @@ extract_function_name <- function(string) {
 #'
 extract_function_name2 <- function(string){
 
-  foo_def_start <- stringr::str_locate_all(pattern = "(\\s|=|-)function\\s*\\(",
-                                           string = string)[[1]][1,1]
+  string <- stringr::str_replace_all(string,
+                           pattern = c("\n"),
+                           replacement = " ")
 
-  assign_operand_locations <- stringr::str_locate_all(pattern = c("=|<-"),
-                                                string = string)[[1]][, "start"]
+  foo_assign_operand_location <- stringr::str_locate_all(pattern = "(\\s|=|<-)function\\s*\\(",
+                                           string = string) |>
+                                  unlist() |>
+                                  head(1)
 
-  foo_assign_operand_location <- find_previous_vector_element(value  = foo_def_start,
-                                                              vector = assign_operand_locations)
+  #assign_operand_locations <- stringr::str_locate_all(pattern = c("=|<-"),
+  #                                                    string = string)[[1]][, "start"]
 
-  foo_name <- substr(string, 1, foo_assign_operand_location-1) |>
+  #foo_assign_operand_location <- find_previous_vector_element(value  = foo_def_start,
+  #                                                            vector = assign_operand_locations)
+
+  v_chars <- substr(x = string,
+                     start = 1,
+                     stop =  foo_assign_operand_location - 1) |>
     stringr::str_replace_all(pattern = c("\n"),
                              replacement = " ") |>
     strsplit(split = " ") |>
-    unlist() |>
-    utils::tail(n = 1)
+    unlist()
+
+
+    foo_name <- v_chars[which(!(v_chars %in% c("", "=", "<-")))] |>
+                  utils::tail(n = 1)
+
+    # replace any persisting assignment
+    foo_name <- stringr::str_replace_all(pattern = c("=|<-"),
+                             string = foo_name,
+                             replacement = "")
 
  return(foo_name)
 
 }
 
-
+extract_function_name2(string = "  # hi this is silly ...
+myFoo <-
+function () {
+print('hi')
+}
+                       ")
 
 
 

--- a/R/cheers_checker.R
+++ b/R/cheers_checker.R
@@ -142,13 +142,6 @@ extract_function_name2 <- function(string){
 
 }
 
-extract_function_name2(string = "  # hi this is silly ...
-myFoo <-
-function () {
-print('hi')
-}
-                       ")
-
 
 
 

--- a/man/get_file_cheers_classifications.Rd
+++ b/man/get_file_cheers_classifications.Rd
@@ -7,7 +7,7 @@
 get_file_cheers_classifications(
   filename,
   cheers_pattern,
-  function_pattern = "function\\\\("
+  function_pattern = "(\\\\s|=|-)function\\\\("
 )
 }
 \arguments{


### PR DESCRIPTION
This is a potential clunky solution.

1) Replace all row breaks with a line space (L109)
2) Slightly tidier version of getting the first character location in the '<-function(' string (L116)
3) Throw away everything after that point and split by spaces (words) (L129)
4) Replace any persisting assignment (L137)

This is all quite clunky. There must be a better way of achieving this but I'm struggling.

Also note:
This will currently break the code, due to the comment. These lines need to be removed first - but this is a stupid error.

```
test <- 
# some comment
function(a, b,c)
```
